### PR TITLE
Remove double quotes from string

### DIFF
--- a/engine/src/file/language.rs
+++ b/engine/src/file/language.rs
@@ -56,7 +56,7 @@ fn find_mutable_items(string: &str) -> Vec<(String, String)> {
         items.push((
             result.to_string(),
             format!(
-                r#"{:?}"#,
+                r#"{}"#,
                 OPERATOR_CHARSET.iter().find(|&&x| x != result).unwrap()
             ),
         ));
@@ -66,7 +66,7 @@ fn find_mutable_items(string: &str) -> Vec<(String, String)> {
         items.push((
             result.to_string(),
             format!(
-                r#"{:?}"#,
+                r#"{}"#,
                 EQ_OPERATOR_CHARSET.iter().find(|&&x| x != result).unwrap()
             ),
         ));


### PR DESCRIPTION
The old regex was returning double-quoted strings. Now it is the string by itself